### PR TITLE
Avoid Adding Attributes to `<title>` for Svelte’s Benefit

### DIFF
--- a/src/coer/transform.ts
+++ b/src/coer/transform.ts
@@ -6,10 +6,13 @@ import compilerVue from './compiler/vue'
 function addHtmlAttr(filename: string, line: string, loc: number) {
   // match a single div, no attr <div></div>
   const cwd = process.cwd()
-  const htmlTagReg1 = /<(\w+)(\s*>)/g
+  const htmlTagReg1 = /<(\w+)(\s*\/?>)/g
   const htmlTagReg2 = /<(\w+)\s+([\w|:])/g
   // stitching html parameters fileName: location
-  const replaceValue = `<$1 data-loc="${filename.replace(cwd, '')}:${loc}" $2`
+  const replaceValue = (_whole: string, tag: string, rest: string) => {
+    let locAttr = ` data-loc="${filename.replace(cwd, '')}:${loc}" `
+    return `<${tag}${tag !== 'title' ? locAttr : ''}${rest}`
+  }
   const result = line.replace(htmlTagReg2, replaceValue)
     .replace(htmlTagReg1, replaceValue)
   return result

--- a/src/coer/transform.ts
+++ b/src/coer/transform.ts
@@ -10,7 +10,7 @@ function addHtmlAttr(filename: string, line: string, loc: number) {
   const htmlTagReg2 = /<(\w+)\s+([\w|:])/g
   // stitching html parameters fileName: location
   const replaceValue = (_whole: string, tag: string, rest: string) => {
-    let locAttr = ` data-loc="${filename.replace(cwd, '')}:${loc}" `
+    const locAttr = ` data-loc="${filename.replace(cwd, '')}:${loc}" `
     return `<${tag}${tag !== 'title' ? locAttr : ''}${rest}`
   }
   const result = line.replace(htmlTagReg2, replaceValue)


### PR DESCRIPTION
If there are any attributes on the `<title>` element, it will trigger [an error](https://svelte.dev/docs/svelte/compiler-errors#title_illegal_attribute) in the Svelte compiler: "`<title> cannot have attributes nor directives`" as per issue #73.

This pull request avoids adding the `data-loc` attribute to `<title>` tags so as to eliminate this error. Since `<title>` tags do not render as part of the page, this should not affect the functionality of the inspector.

*(Also, it adds a `/?` to the tag regex to allow it to match empty tags.)*